### PR TITLE
Fix: add registry_id to order_id generation params

### DIFF
--- a/sources/main.move
+++ b/sources/main.move
@@ -74,6 +74,9 @@ public struct Refunded has copy, drop {
     order_id: vector<u8>,
 }
 
+public struct RegistryCreated has copy, drop {
+    registry_id: ID
+}
 
 // ================ Public Functions ================
 /// Creates a new registry for atomic swaps of a specific coin type
@@ -85,6 +88,7 @@ public fun create_orders_registry<CoinType>(ctx: &mut TxContext): ID {
     };
     let orders_reg_id = object::uid_to_inner(&orders_reg.id);
     transfer::share_object(orders_reg);
+    event::emit(RegistryCreated {registry_id: orders_reg_id});
     orders_reg_id
 }
 

--- a/sources/main.move
+++ b/sources/main.move
@@ -60,6 +60,7 @@ public struct Initiated has copy, drop {
     order_id: vector<u8>,
     secret_hash: vector<u8>,
     amount: u64,
+    destination_data: vector<u8>
 }
 
 /// Emitted when a swap is redeemed
@@ -108,6 +109,7 @@ public fun initiate<CoinType>(
     secret_hash: vector<u8>,
     amount: u64,
     timelock: u256,
+    destination_data: vector<u8>,
     coins: Coin<CoinType>,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -123,6 +125,7 @@ public fun initiate<CoinType>(
         secret_hash,
         amount,
         timelock,
+        destination_data,
         coins,
         clock,
         ctx,
@@ -147,6 +150,7 @@ public fun initiate_on_behalf<CoinType>(
     secret_hash: vector<u8>,
     amount: u64,
     timelock: u256,
+    destination_data: vector<u8>,
     coins: Coin<CoinType>,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -163,6 +167,7 @@ public fun initiate_on_behalf<CoinType>(
         secret_hash,
         amount,
         timelock,
+        destination_data,
         coins,
         clock,
         ctx,
@@ -388,6 +393,7 @@ fun initiate_<CoinType>(
     secret_hash: vector<u8>,
     amount: u64,
     timelock: u256,
+    destination_data: vector<u8>,
     coins: Coin<CoinType>,
     clock: &Clock,
     ctx: &mut TxContext,
@@ -414,6 +420,7 @@ fun initiate_<CoinType>(
         order_id,
         secret_hash,
         amount,
+        destination_data,
     });
 }
 

--- a/sources/main.move
+++ b/sources/main.move
@@ -74,6 +74,7 @@ public struct Refunded has copy, drop {
     order_id: vector<u8>,
 }
 
+
 // ================ Public Functions ================
 /// Creates a new registry for atomic swaps of a specific coin type
 /// @param ctx The transaction context
@@ -210,6 +211,7 @@ public fun redeem_swap<CoinType>(
 ) {
     assert!(dynamic_field::exists_(&orders_reg.id, order_id), EOrderNotInitiated);
 
+    let registry_addr = object::uid_to_address(&orders_reg.id);
     let order: &mut Order<CoinType> = dynamic_field::borrow_mut(&mut orders_reg.id, order_id);
 
     assert!(!order.is_fulfilled, EOrderFulfilled);
@@ -222,6 +224,8 @@ public fun redeem_swap<CoinType>(
         redeemer,
         order.timelock,
         order.amount,
+        registry_addr
+
     );
 
     assert!(calc_order_id == order_id, EIncorrectSecret);
@@ -324,6 +328,7 @@ fun create_order_id(
     redeemer: address,
     timelock: u256,
     amount: u64,
+    reg_id: address
 ): vector<u8> {
     // @note sui_chain_id needs to be changed for testnet
     // sui_chain_id (testnet) = x"0000000000000000000000000000000000000000000000000000000000000001"
@@ -337,6 +342,7 @@ fun create_order_id(
     vector::append(&mut data, address::to_bytes(redeemer));
     vector::append(&mut data, timelock_bytes);
     vector::append(&mut data, amount);
+    vector::append(&mut data, address::to_bytes(reg_id));
     hash::sha2_256(data)
 }
 
@@ -382,7 +388,8 @@ fun initiate_<CoinType>(
     clock: &Clock,
     ctx: &mut TxContext,
 ) {
-    let order_id = create_order_id(secret_hash, initiator, redeemer, timelock, amount);
+    let reg_id = object::uid_to_address(&orders_reg.id);
+    let order_id = create_order_id(secret_hash, initiator, redeemer, timelock, amount, reg_id);
 
     assert!(!dynamic_field::exists_(&orders_reg.id, order_id), EDuplicateOrder);
 
@@ -416,14 +423,17 @@ public fun get_order<CoinType>(
     dynamic_field::borrow(&orders_reg.id, order_id)
 }
 #[test_only]
-public fun generate_order_id(
+public fun generate_order_id<ID: key>(
     secret_hash: vector<u8>,
     initiator: address,
     redeemer: address,
     timelock: u256,
     amount: u64,
+    registry: &ID
 ): vector<u8> {
-    create_order_id(secret_hash, initiator, redeemer, timelock, amount)
+    let id = object::id_address(registry);
+    let order_id = create_order_id(secret_hash, initiator, redeemer, timelock, amount, id);
+    order_id
 }
 #[test_only]
 public fun get_refund_typehash(): vector<u8> {

--- a/tests/test.move
+++ b/tests/test.move
@@ -10,6 +10,7 @@ use sui::coin::{Self, Coin, TreasuryCap};
 use sui::hash::blake2b256;
 use sui::sui::{Self, SUI};
 use sui::test_scenario::{Self as ts, Scenario};
+use sui::object::uid_to_inner;
 
 // Test addresses
 const ADMIN: address = @0xAD;
@@ -79,6 +80,7 @@ fun initialize_test_swap(
     timelock: u256,
 ): vector<u8> {
     let (_, secret_hash) = generate_secret();
+    let order_id;
     // Mint coins to the initiator
     ts::next_tx(scenario, ADMIN);
     {
@@ -103,17 +105,19 @@ fun initialize_test_swap(
             ts::ctx(scenario),
         );
 
-        ts::return_shared(registry);
-    };
-
-    // Return order ID for further operations
-    AtomicSwap::generate_order_id(
+    order_id = AtomicSwap::generate_order_id(
         secret_hash,
         initiator_address,
         generate_address(redeemer_pubk),
         timelock,
         amount,
-    )
+        &registry
+    );
+        ts::return_shared(registry);
+    };
+
+    // Return order ID for further operations
+    order_id
 }
 
 // Test registry creation
@@ -1195,6 +1199,7 @@ fun test_init_on_behalf() {
             redeemer_address,
             TIMELOCK,
             SWAP_AMOUNT,
+            &registry
         );
         AtomicSwap::redeem_swap(
             &mut registry,
@@ -1305,7 +1310,7 @@ fun test_instant_refund() {
 
         // Generated using fastcrypto-cli
         let refund_signature =
-            x"0ccce0d58570ad53b96dbdcb5d0b0043820f9818e0b5e25032019ada92d928ac15d3ccc18043e7387940a7dd03baed3420b5bb0b07da599c135629f543d72e04";
+            x"3b887355dab78f0e0651994e9e5c537604b50c4a5780315ecbfe7b5853e785e98e7ff3d7b638b8a9a65466e92c1b5ff4bd00df86b04c6f4aacc37a027c144609";
 
         AtomicSwap::instant_refund(
             &mut registry,

--- a/tests/test.move
+++ b/tests/test.move
@@ -19,7 +19,7 @@ const REDEEMER: address = @0xA2;
 // Test constants
 const SWAP_AMOUNT: u64 = 1000;
 const TIMELOCK: u256 = 3600000; // 1 hour in milliseconds
-
+// const DESTINATION_DATA: vector<u8> = [];
 // Setup function that creates a test environment
 fun setup(): Scenario {
     let mut scenario = ts::begin(ADMIN);
@@ -100,6 +100,7 @@ fun initialize_test_swap(
             secret_hash,
             amount,
             timelock,
+            vector::empty<u8>(),
             init_coins,
             clock,
             ts::ctx(scenario),
@@ -163,6 +164,7 @@ fun test_init_swap() {
             secret_hash,
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -387,6 +389,7 @@ fun test_revert_init_duplicate_order() {
             secret_hash,
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -439,6 +442,7 @@ fun test_revert_init_on_behalf_duplicate_order() {
             secret_hash,
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -537,6 +541,7 @@ fun test_revert_init_same_initiator_redeemer() {
             secret_hash,
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -579,6 +584,7 @@ fun test_revert_init_on_behalf_same_initiator_redeemer() {
             secret_hash,
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -683,6 +689,7 @@ fun test_revert_init_zero_timelock() {
             secret_hash,
             SWAP_AMOUNT,
             0, // Zero timelock
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -725,6 +732,7 @@ fun test_revert_init_on_behalf_zero_timelock() {
             secret_hash,
             SWAP_AMOUNT,
             0, // Zero timelock
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -767,6 +775,7 @@ fun test_revert_init_big_timelock() {
             secret_hash,
             SWAP_AMOUNT,
             604800001, // >7 days timelock
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -809,6 +818,7 @@ fun test_revert_init_on_behalf_big_timelock() {
             secret_hash,
             SWAP_AMOUNT,
             604800001, // >7 days timelock
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -851,6 +861,7 @@ fun test_revert_init_on_behalf_invalid_secret_hash_length() {
             x"1234",
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -892,6 +903,7 @@ fun test_revert_init_invalid_secret_hash_length() {
             x"1234",
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -934,6 +946,7 @@ fun test_revert_init_swap_zero_amount() {
             secret_hash,
             0, // Zero amount
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -976,6 +989,7 @@ fun test_revert_init_on_behalf_zero_amount() {
             secret_hash,
             0, // Zero amount
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -1019,6 +1033,7 @@ fun test_revert_init_on_behalf_zero_initiator() {
             secret_hash,
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -1060,6 +1075,7 @@ fun test_revert_init_swap_insufficient_balance() {
             secret_hash,
             SWAP_AMOUNT, // Amount greater than available coins
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -1102,6 +1118,7 @@ fun test_revert_init_on_behalf_insufficient_balance() {
             secret_hash,
             SWAP_AMOUNT, // Amount greater than available coins
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -1143,6 +1160,7 @@ fun test_revert_init_on_behalf_same_funder_redeemer() {
             secret_hash,
             SWAP_AMOUNT, // Amount greater than available coins
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),
@@ -1182,6 +1200,7 @@ fun test_init_on_behalf() {
             secret_hash,
             SWAP_AMOUNT,
             TIMELOCK,
+            vector::empty<u8>(),
             init_coins,
             &clock,
             ts::ctx(&mut scenario),


### PR DESCRIPTION
- add `registry_id` to `order_id` generation parameters
- add a new event `RegistryCreated`
- add `destination_data: vector<u8>` as parameter to `initiate` and `initiate_on_behalf` functions
- fix corresponding tests